### PR TITLE
fix `Cannot find module 'babel-core'`

### DIFF
--- a/lib/compilers/babel-compiler.js
+++ b/lib/compilers/babel-compiler.js
@@ -1,4 +1,4 @@
-const babel = require('babel-core')
+const babel = require('@babel/core')
 const loadBabelConfig = require('../load-babel-config.js')
 
 module.exports = function compileBabel (scriptContent, inputSourceMap, inlineConfig, vueJestConfig, filePath) {


### PR DESCRIPTION
because the babel7 used name @babel/core. So I change the require statement.
![image](https://user-images.githubusercontent.com/11012329/54653134-7ceea100-4af4-11e9-9279-04c084eb5871.png)
